### PR TITLE
Added headers parameter which can be used to pass custom headers

### DIFF
--- a/flagsmith-core.js
+++ b/flagsmith-core.js
@@ -21,7 +21,7 @@ const Flagsmith = class {
     }
 
     getJSON = (url, method, body) => {
-        const { environmentID } = this;
+        const { environmentID, headers } = this;
         const options = {
             method: method || 'GET',
             body,
@@ -31,6 +31,10 @@ const Flagsmith = class {
         };
         if (method && method !== "GET")
             options.headers['Content-Type'] = 'application/json; charset=utf-8'
+
+        if (headers) {
+            Object.assign(options.headers, headers)
+        }
         return fetch(url, options)
             .then(res => {
                 return res.text()
@@ -145,6 +149,7 @@ const Flagsmith = class {
     init({
         environmentID,
         api = defaultAPI,
+        headers,
         onChange,
         cacheFlags,
         onError,
@@ -159,6 +164,7 @@ const Flagsmith = class {
         return new Promise((resolve, reject) => {
             this.environmentID = environmentID;
             this.api = api;
+            this.headers = headers;
             this.getFlagInterval = null;
             this.analyticsInterval = null;
             this.onChange = onChange;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare class IFlagsmith {
     init:(config: {
         environmentID: string // your Bullet Train environment id
         api?: string // the api you wish to use, important if self hosting
+        headers?: object // pass custom headers for flagsmith api calls
         AsyncStorage?: any // an AsyncStorage implementation
         cacheFlags?: boolean // whether to local storage flags, needs AsyncStorage defined
         preventFetch?: boolean // whether to prevent fetching flags on init


### PR DESCRIPTION
Added a header parameter to `flagsmith.init`. Accepts `{header1: "data1", header2: function1()}`.

We're planning to run flagsmith behind a gateway and the gateway will prevent unauthorised identity / trait manipulation will happen via clients.